### PR TITLE
Added test for binary secret creation/retrieval

### DIFF
--- a/client/src/test/java/org/conjur/sdk/endpoint/SecretsApiTest.java
+++ b/client/src/test/java/org/conjur/sdk/endpoint/SecretsApiTest.java
@@ -14,6 +14,7 @@
 package org.conjur.sdk.endpoint;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -417,6 +418,23 @@ public class SecretsApiTest extends ConfiguredTest {
             aliceApi.getSecrets("\0");
         } catch (ApiException e) {
             Assert.assertEquals(422, e.getCode());
+        }
+    }
+
+    @Test
+    public void createBinarySecretTest() throws ApiException {
+        byte[] byteData = new byte[]{1, 126, 10, 35};
+        // Use this charset so we dont lose any data in the transition from bytes to string
+        String testData = new String(byteData, StandardCharsets.ISO_8859_1);
+
+        api.createSecret(account, "variable", "testSecret", null, null, testData);
+
+        String result = api.getSecret(account, "variable", "testSecret");
+        Assert.assertEquals(testData, result);
+
+        byte[] resultBytes = result.getBytes();
+        for (int i = 0; i < resultBytes.length; i++) {
+            Assert.assertEquals(byteData[i], resultBytes[i]);
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?
Added new test to ensure binary secrets can be properly set and retrieved.

### What ticket does this PR close?
Resolves #26
Relates to cyberark/conjur-openapi-spec#[Relevant Conjur OpenAPI spec issue number]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
