### PR TITLE
Updated the Auto Authenticate var to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The CONJUR_AUTO_UPDATE_TOKEN variable is now set to true by default
 
 ## [4.0.0] - 6/17/21
 ### Changed

--- a/client/src/main/java/com/cyberark/conjur/sdk/ApiClient.java
+++ b/client/src/main/java/com/cyberark/conjur/sdk/ApiClient.java
@@ -89,7 +89,7 @@ public class ApiClient {
     private String certFile = System.getenv().getOrDefault("CONJUR_CERT_FILE", null);
     private String sslCert = System.getenv().getOrDefault("CONJUR_SSL_CERTIFICATE", null);
     private String apiKey = System.getenv().getOrDefault("CONJUR_AUTHN_API_KEY", null);
-    private boolean autoUpdateAccessToken = System.getenv().getOrDefault("CONJUR_AUTO_UPDATE_TOKEN", "false").toLowerCase().equals("true");
+    private boolean autoUpdateAccessToken = System.getenv().getOrDefault("CONJUR_AUTO_UPDATE_TOKEN", "true").toLowerCase().equals("true");
 
     public String getAccount() {
         return account;


### PR DESCRIPTION
### What does this PR do?
Updated the CONJUR_AUTO_UPDATE_TOKEN environment variable to be set to true by default. This makes more sense for how the client will be used in general and fits better with existing client functionality.

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
