### PR TITLE
Add GitHub Action to auto-refresh Java client

### DIFF
--- a/.github/workflows/refresh_client.yml
+++ b/.github/workflows/refresh_client.yml
@@ -1,0 +1,35 @@
+name: Automate Client Refresh
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  client_refresh:
+    runs-on: ubuntu-latest
+    name: Create PR when Conjur OpenAPI description is updated
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Refresh Java client from OpenAPI description
+        run: |
+          ./bin/refresh_client
+
+      - name: Open PR for updated client
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Automated PR to update Java client
+          branch: openapi-update/auto-pr
+          commit-message: "[automated commit] Refresh Java client"
+          body: |+
+            This PR was opened because a change was detected in Conjur's
+            OpenAPI description:
+
+            https://github.com/cyberark/conjur-openapi-spec
+
+            Please verify that the changes look good.
+            Note: If the OpenAPI description has added new endpoints, then this
+            PR should be updated to include unit testing to maintain test
+            coverage.
+          team-reviewers: |
+            maintainers


### PR DESCRIPTION
### Desired Outcome

The Java SDK currently does not have automation to update the client when changes are made to the Conjur OpenAPI description. This should be updated, so unsuspecting devs aren't surprised by substantial changes client.

### Implemented Changes

Added a GitHub Action at `.github/workflows/refresh_client.yml`.
Runs once daily, calling `bin/refresh_client`, and opening a PR with any changes.
PR will require a review from a maintainer before merging, and may require additional testing.

Still investigating ways to test this Action, without polluting the repo.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
