### PR TITLE
Update okhttp3 to 4.9.2 for security & other deps to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [4.1.0] - 2022-04-01
 
 ### Changed
+- Update okhttp3 to 4.9.2 to resolve 
+  [SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044](https://app.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044)
+  and bump other dependencies to latest version
+  [conjur-sdk-java#74](https://github.com/cyberark/conjur-sdk-java/pull/74)
 - Update OpenAPI spec to version 5.3.0 and add tests for JWT authenticator
   [conjur-sdk-java#70](https://github.com/cyberark/conjur-sdk-java/pull/70)
 - Update project to reflect Trusted Level

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,15 @@ pipeline {
         buildDiscarder(logRotator(numToKeepStr: '30'))
     }
 
+    // "parameterizedCron" is defined by this native Jenkins plugin:
+    //     https://plugins.jenkins.io/parameterized-scheduler/
+    // "getDailyCronString" is defined by us (URL is wrapped):
+    //     https://github.com/conjurinc/jenkins-pipeline-library/blob/master/vars/
+    //     getDailyCronString.groovy
+    triggers {
+        parameterizedCron(getDailyCronString())
+    }
+
     stages {
         stage('Integration Tests') {
             steps {

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -8,36 +8,36 @@ of the license associated with each component.
 
 Section 1: Apache-2.0
 
->>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin/3.8.1
->>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-enforcer-plugin/3.0.0-M1
->>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin/3.0.0-M4
+>>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin/3.10.1
+>>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-enforcer-plugin/3.0.0
+>>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin/3.0.0-M7
 >>> https://mvnrepository.com/artifact/org.apache.maven/maven-plugin-api/3.8.1
->>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-jar-plugin/2.2
->>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-javadoc-plugin/3.1.1
+>>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-jar-plugin/3.2.2
+>>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-javadoc-plugin/3.4.0
 >>> https://mvnrepository.com/artifact/org.apache.maven/maven-plugin-api/2.2.1
->>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-assembly-plugin/3.1.1
->>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-gpg-plugin/1.5
+>>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-assembly-plugin/3.4.2
+>>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-gpg-plugin/3.0.1
 >>> https://commons.apache.org/proper/commons-lang/
 >>> https://mvnrepository.com/artifact/org.scalatestplus/junit-4-13_3/3.2.9.0
 >>> https://mvnrepository.com/artifact/io.swagger/swagger-annotations/1.5.24
 >>> https://mvnrepository.com/artifact/com.google.code.findbugs/jsr305/3.0.2
->>> https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp/3.14.7
->>> https://mvnrepository.com/artifact/com.squareup.okhttp3/logging-interceptor/3.14.7
+>>> https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp/4.10.0
+>>> https://mvnrepository.com/artifact/com.squareup.okhttp3/logging-interceptor/4.10.0
 >>> https://mvnrepository.com/artifact/io.gsonfire/gson-fire/1.8.4
 >>> https://mvnrepository.com/artifact/com.google.code.gson/gson/2.8.6
 
 Section 2: BSD-3-Clause
 
->>> https://mvnrepository.com/artifact/org.threeten/threetenbp/1.4.3
+>>> https://mvnrepository.com/artifact/org.threeten/threetenbp/1.6.0
 
 Section 3: MIT
 
->>> https://mvnrepository.com/artifact/org.codehaus.mojo/build-helper-maven-plugin/1.1
->>> https://mvnrepository.com/artifact/org.mockito/mockito-core/3.11.1
+>>> https://mvnrepository.com/artifact/org.codehaus.mojo/build-helper-maven-plugin/3.3.0
+>>> https://mvnrepository.com/artifact/org.mockito/mockito-core/4.6.1
 
 Section 4: EPL
 
->>> https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin/0.8.7
+>>> https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin/0.8.8
 
 APPENDIX: Standard License Files and Templates
 
@@ -50,7 +50,7 @@ APPENDIX: Standard License Files and Templates
 
 Apache-2.0 License is applicable to the following component(s).
 
->>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin/3.8.1
+>>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin/3.10.1
 
 Copyright <YEAR> <COPYRIGHT HOLDER>
 
@@ -66,7 +66,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-enforcer-plugin/3.0.0-M1
+>>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-enforcer-plugin/3.0.0
 
 Copyright <YEAR> <COPYRIGHT HOLDER>
 
@@ -82,7 +82,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin/3.0.0-M4
+>>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin/3.0.0-M7
 
 Copyright <YEAR> <COPYRIGHT HOLDER>
 
@@ -114,7 +114,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-jar-plugin/2.2
+>>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-jar-plugin/3.2.2
 
 Copyright <YEAR> <COPYRIGHT HOLDER>
 
@@ -130,7 +130,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-javadoc-plugin/3.1.1
+>>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-javadoc-plugin/3.4.0
 
 Copyright <YEAR> <COPYRIGHT HOLDER>
 
@@ -162,7 +162,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-assembly-plugin/3.1.1
+>>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-assembly-plugin/3.4.2
 
 Copyright <YEAR> <COPYRIGHT HOLDER>
 
@@ -178,7 +178,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-gpg-plugin/1.5
+>>> https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-gpg-plugin/3.0.1
 
 Copyright <YEAR> <COPYRIGHT HOLDER>
 
@@ -258,7 +258,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp/3.14.7
+>>> https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp/4.10.0
 
 Copyright <YEAR> <COPYRIGHT HOLDER>
 
@@ -274,7 +274,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
->>> https://mvnrepository.com/artifact/com.squareup.okhttp3/logging-interceptor/3.14.7
+>>> https://mvnrepository.com/artifact/com.squareup.okhttp3/logging-interceptor/4.10.0
 
 Copyright <YEAR> <COPYRIGHT HOLDER>
 
@@ -327,7 +327,7 @@ limitations under the License.
 
 BSD-3-Clause License is applicable to the following component(s).
 
->>> https://mvnrepository.com/artifact/org.threeten/threetenbp/1.4.3
+>>> https://mvnrepository.com/artifact/org.threeten/threetenbp/1.6.0
 
 Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos.
 
@@ -363,7 +363,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 MIT License is applicable to the following component(s).
 
->>> https://mvnrepository.com/artifact/org.codehaus.mojo/build-helper-maven-plugin/1.1
+>>> https://mvnrepository.com/artifact/org.codehaus.mojo/build-helper-maven-plugin/3.3.0
 
 Copyright (c) 2008 Dan Tran dantran@gmail.com
 
@@ -388,7 +388,7 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
->>> https://mvnrepository.com/artifact/org.mockito/mockito-core/3.11.1
+>>> https://mvnrepository.com/artifact/org.mockito/mockito-core/4.6.1
 
 The MIT License
 
@@ -417,7 +417,7 @@ THE SOFTWARE.
 
 EPL License is applicable to the following component(s).
 
->>> https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin/0.8.7
+>>> https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin/0.8.8
 
 Eclipse Public License - v 2.0
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -38,7 +38,7 @@
            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <configuration>
                     <fork>true</fork>
                     <meminitial>128m</meminitial>
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -62,7 +62,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>2.2.0</version>
+                                    <version>3.2.5</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>
@@ -72,13 +72,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M4</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <argLine>@{argLine} -Xms512m -Xmx1500m</argLine>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -96,15 +97,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.2.2</version>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>jar</goal>
                             <goal>test-jar</goal>
                         </goals>
                     </execution>
                 </executions>
+
                 <configuration>
                 </configuration>
             </plugin>
@@ -112,7 +113,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.10</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>
@@ -143,7 +144,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -166,7 +167,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -182,7 +183,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>6.2.2</version>
+                <version>7.1.1</version>
                 <configuration>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                 </configuration>
@@ -197,7 +198,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>com/cyberark/conjur/sdk/model/**/*</exclude>
@@ -222,7 +223,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.4.2</version>
 
                 <configuration>
                     <descriptorRefs>
@@ -280,7 +281,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
+                        <version>1.6.13</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
@@ -291,7 +292,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>2.3</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -326,7 +327,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -403,7 +404,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.11.0</version>
+            <version>4.6.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -412,12 +413,12 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <swagger-core-version>1.5.24</swagger-core-version>
-        <okhttp-version>3.14.7</okhttp-version>
+        <okhttp-version>4.10.0</okhttp-version>
         <gson-version>2.9.0</gson-version>
-        <commons-lang3-version>3.10</commons-lang3-version>
-        <threetenbp-version>1.4.3</threetenbp-version>
+        <commons-lang3-version>3.12.0</commons-lang3-version>
+        <threetenbp-version>1.6.0</threetenbp-version>
         <javax-annotation-version>1.3.2</javax-annotation-version>
-        <junit-version>4.13.1</junit-version>
+        <junit-version>4.13.2</junit-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/templates/libraries/okhttp-gson/pom.mustache
+++ b/templates/libraries/okhttp-gson/pom.mustache
@@ -45,7 +45,7 @@
            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <configuration>
                     <fork>true</fork>
                     <meminitial>128m</meminitial>
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -69,7 +69,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>2.2.0</version>
+                                    <version>3.2.5</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>
@@ -79,13 +79,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M4</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <argLine>@{argLine} -Xms512m -Xmx1500m</argLine>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -103,11 +104,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.2.2</version>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>jar</goal>
                             <goal>test-jar</goal>
                         </goals>
                     </execution>
@@ -119,7 +119,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.10</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>
@@ -150,7 +150,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -173,7 +173,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -189,7 +189,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>6.2.2</version>
+                <version>7.1.1</version>
                 <configuration>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                 </configuration>
@@ -204,7 +204,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>com/cyberark/conjur/sdk/model/**/*</exclude>
@@ -229,7 +229,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.4.2</version>
 
                 <configuration>
                     <descriptorRefs>
@@ -287,7 +287,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
+                        <version>1.6.13</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
@@ -298,7 +298,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>2.3</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -333,7 +333,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -389,7 +389,7 @@
         <dependency>
             <groupId>org.apache.oltu.oauth2</groupId>
             <artifactId>org.apache.oltu.oauth2.client</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
         </dependency>
         {{/hasOAuthMethods}}
         <dependency>
@@ -457,7 +457,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.11.0</version>
+            <version>4.6.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -466,17 +466,17 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <swagger-core-version>1.5.24</swagger-core-version>
-        <okhttp-version>3.14.7</okhttp-version>
+        <okhttp-version>4.10.0</okhttp-version>
         <gson-version>2.9.0</gson-version>
-        <commons-lang3-version>3.10</commons-lang3-version>
+        <commons-lang3-version>3.12.0</commons-lang3-version>
         {{#joda}}
-        <jodatime-version>2.9.9</jodatime-version>
+        <jodatime-version>2.10.14</jodatime-version>
         {{/joda}}
         {{#threetenbp}}
-        <threetenbp-version>1.4.3</threetenbp-version>
+        <threetenbp-version>1.6.0</threetenbp-version>
         {{/threetenbp}}
         <javax-annotation-version>1.3.2</javax-annotation-version>
-        <junit-version>4.13.1</junit-version>
+        <junit-version>4.13.2</junit-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Update okhttp3 to a non-vulnerable version and update other dependencies in client/pom.xml

### Implemented Changes

- Update okhttp3 to 4.9.2
- Update other deps in client/pom.xml to latest non-alpha/RC versions
- Adds nightly build trigger

Addresses CONJSE-1454
