### PR TITLE
Build client with Maven container instead of local Maven CLI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     //     https://github.com/conjurinc/jenkins-pipeline-library/blob/master/vars/
     //     getDailyCronString.groovy
     triggers {
-        parameterizedCron(getDailyCronString())
+        parameterizedCron(getDailyCronString("%NIGHTLY=true"))
     }
 
     stages {

--- a/bin/build
+++ b/bin/build
@@ -5,10 +5,10 @@ set -e
 cd "$(dirname "$0")/.." || (echo "Could not cd to parent dir"; exit 1)
 source bin/util
 
-pushd client
-
-mvn clean package -DskipTests=true
-
-popd
+docker run --rm \
+  -v "${PWD}/client":/client \
+  -w /client \
+  maven:3-openjdk-16 \
+  mvn clean package -DskipTests=true
 
 announce "Output available in ./client/target"

--- a/bin/test_integration
+++ b/bin/test_integration
@@ -6,7 +6,7 @@ cd "$(dirname "$0")/.." || (echo "Could not cd to parent dir"; exit 1)
 
 source bin/util
 
-regen_client=true
+regen_client=false
 rebuild_conjur=true
 major_java_version=16
 install=""
@@ -53,7 +53,7 @@ print_help(){
   echo -e "\tThe --no-rebuild-conjur flag will prevent the conjur image from rebuilding"
   echo -e "\t\tWarning: this may cause some tests to fail"
   echo
-  echo -e "\tThe --no-regen-client flag will prevent the client from re-generating before tests run"
+  echo -e "\tThe --regen-client flag will re-generating the client before tests run"
   echo
   echo -e "\tThe -d flag will turn on debug mode for the integration test runs"
   echo
@@ -121,8 +121,8 @@ do
     --no-rebuild-conjur)
       rebuild_conjur=false
       ;;
-    --no-regen-client)
-      regen_client=false
+    --regen-client)
+      regen_client=true
       ;;
     -j|--java-version)
       major_java_version=$1


### PR DESCRIPTION
### Desired Outcome

Use Maven container instead of local Maven CLI to build Conjur client.

### Implemented Changes

- Use Maven container instead of local Maven CLI to build Conjur client
- Fix nightly Jenkins build trigger
- `bin/test_integration` script used to refresh the client by default before testing, this has been updated to optional, but not default behavior

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
