### PR TITLE
Fix Integration Tests: Roles and Resources

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,13 +8,11 @@ pipeline {
         buildDiscarder(logRotator(numToKeepStr: '30'))
     }
 
-    // "parameterizedCron" is defined by this native Jenkins plugin:
-    //     https://plugins.jenkins.io/parameterized-scheduler/
     // "getDailyCronString" is defined by us (URL is wrapped):
     //     https://github.com/conjurinc/jenkins-pipeline-library/blob/master/vars/
     //     getDailyCronString.groovy
     triggers {
-        parameterizedCron(getDailyCronString("%NIGHTLY=true"))
+        cron(getDailyCronString())
     }
 
     stages {

--- a/client/src/test/java/com/cyberark/conjur/sdk/endpoint/ResourcesApiTest.java
+++ b/client/src/test/java/com/cyberark/conjur/sdk/endpoint/ResourcesApiTest.java
@@ -37,6 +37,7 @@ public class ResourcesApiTest extends ConfiguredTest {
     private String rootPolicy = String.format("%s:policy:root", account);
     private String onePassword = String.format("%s:variable:one/password", account);
     private String testSecret = String.format("%s:variable:testSecret", account);
+    private String admin = String.format("%s:user:admin", account);
     private String alice = String.format("%s:user:alice", account);
     private String aliceKey = String.format("%s:public_key:user/alice/laptop", account);
     private String bob = String.format("%s:user:bob", account);
@@ -49,7 +50,7 @@ public class ResourcesApiTest extends ConfiguredTest {
 
     private final String[] resourceIds = {
         rootPolicy, onePassword, testSecret,
-        alice, aliceKey, bob,
+        admin, alice, aliceKey, bob,
         ldapPolicy, ldapWebservice, ldapGroup,
         gcpPolicy, gcpWebservice, gcpGroup,
     };

--- a/client/src/test/java/com/cyberark/conjur/sdk/endpoint/roles/RolesApiTest.java
+++ b/client/src/test/java/com/cyberark/conjur/sdk/endpoint/roles/RolesApiTest.java
@@ -70,13 +70,14 @@ public class RolesApiTest extends RoleTest {
     }
 
     /**
-     * Update or modify an existing role membership. Test case for 403 response code.
+     * Test case for 404 response code when the requesting user does not have
+     * permission to read the requested member.
      *
      * @throws ApiException
      *          if the Api call fails
      */
     @Test
-    public void addMemberToRoleTest403() throws ApiException {
+    public void addMemberToRoleTest404a() throws ApiException {
         String member = BOB_ID;
         try {
             aliceApi.addMemberToRole(
@@ -87,18 +88,18 @@ public class RolesApiTest extends RoleTest {
                 member
             );
         } catch (ApiException e) {
-            Assert.assertEquals(403, e.getCode());
+            Assert.assertEquals(404, e.getCode());
         }
     }
 
     /**
-     * Update or modify an existing role membership. Test case for 404 response code.
+     * Test case for 404 response code when the requested member does not exist.
      *
      * @throws ApiException
      *          if the Api call fails
      */
     @Test
-    public void addMemberToRoleTest404() throws ApiException {
+    public void addMemberToRoleTest404b() throws ApiException {
         try {
             api.addMemberToRole(
                 account,
@@ -161,13 +162,14 @@ public class RolesApiTest extends RoleTest {
     }
 
     /**
-     * Deletes an existing role membership. Test case for 403 response code.
+     * Deletes an existing role membership. Test case for 404 response code when
+     * the requesting user does not have permission to read the requested member.
      *
      * @throws ApiException
      *          if the Api call fails
      */
     @Test
-    public void removeMemberFromRoleTest403() throws ApiException {
+    public void removeMemberFromRoleTest404a() throws ApiException {
         String kind = "group";
         String identifier = "userGroup";
         String members = "";
@@ -181,18 +183,19 @@ public class RolesApiTest extends RoleTest {
                 member
             );
         } catch (ApiException e) {
-            Assert.assertEquals(403, e.getCode());
+            Assert.assertEquals(404, e.getCode());
         }
     }
 
     /**
-     * Deletes an existing role membership. Test case for 404 response code.
+     * Deletes an existing role membership. Test case for 404 response code when
+     * the requested member does not exist.
      *
      * @throws ApiException
      *          if the Api call fails
      */
     @Test
-    public void removeMemberFromRoleTest404() throws ApiException {
+    public void removeMemberFromRoleTest404b() throws ApiException {
         String kind = "group";
         String identifier = "userGroup";
         String members = "";
@@ -253,13 +256,14 @@ public class RolesApiTest extends RoleTest {
     }
 
     /**
-     * Get role information. Test case for 403 response code.
+     * Get role information. Test case for 404 response code when the requesting
+     * user does not have permission to read the requested role.
      *
      * @throws ApiException
      *          if the Api call fails
      */
     @Test
-    public void showRoleTest403() throws ApiException {
+    public void showRoleTest404a() throws ApiException {
         String kind = "user";
         String identifier = "admin";
 
@@ -270,18 +274,19 @@ public class RolesApiTest extends RoleTest {
                 identifier
             );
         } catch (ApiException e) {
-            Assert.assertEquals(403, e.getCode());
+            Assert.assertEquals(404, e.getCode());
         }
     }
 
     /**
-     * Get role information. Test case for 404 response code.
+     * Get role information. Test case for 404 response code when the requested
+     * role does not exist.
      *
      * @throws ApiException
      *          if the Api call fails
      */
     @Test
-    public void showRoleTest404() throws ApiException {
+    public void showRoleTest404b() throws ApiException {
         String kind = "user";
         String identifier = "nonexist";
 


### PR DESCRIPTION
### Desired Outcome

Fix integration tests.

### Implemented Changes

1. Include admin user in Resources API test case. Admin users now have a corresponding resource: https://github.com/cyberark/conjur/pull/2757
2. Update test cases for Roles API. Roles API endpoints now return 404 when the caller has insufficient privilege: https://github.com/cyberark/conjur/pull/2755

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
