### PR TITLE
Fix volume path for release deployment

### DIFF
--- a/bin/deploy-release
+++ b/bin/deploy-release
@@ -15,7 +15,7 @@ export TAG=${TAG_NAME//"v"}
 docker run --rm \
   -e OSSRH_USERNAME \
   -e OSSRH_PASSWORD \
-  -v "$PWD:/cyberark/conjur-sdk-java" \
+  -v "$PWD/client:/cyberark/conjur-sdk-java" \
   -v "$GPG_PASSWORD:/gpg_password" \
   -v "$GPG_PRIVATE_KEY:/gpg_key" \
   -w /cyberark/conjur-sdk-java maven:3-jdk-8 \

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -183,8 +183,9 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>7.1.1</version>
+                <version>7.4.4</version>
                 <configuration>
+                    <cveDownloadWait>20000</cveDownloadWait>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                 </configuration>
                 <executions>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,5 +77,5 @@ services:
 
 networks:
   default:
-    external:
-      name: conjur-sdk-java
+    external: true
+    name: conjur-sdk-java

--- a/templates/libraries/okhttp-gson/pom.mustache
+++ b/templates/libraries/okhttp-gson/pom.mustache
@@ -189,8 +189,9 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>7.1.1</version>
+                <version>7.4.4</version>
                 <configuration>
+                    <cveDownloadWait>20000</cveDownloadWait>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                 </configuration>
                 <executions>


### PR DESCRIPTION
The mvn deployment script needs to be run from the client dir (as opposed to the project root) - otherwise the release doesn't get published to maven central: https://mvnrepository.com/artifact/com.cyberark/conjur-sdk-java

Also fixes some deprecation warnings with the docker-compose network and some flakiness in the dependency-check plugin by increasing the timeout
